### PR TITLE
Fixed #139 : `--scheme ignore` works again

### DIFF
--- a/HookTest/capitains_units/cts.py
+++ b/HookTest/capitains_units/cts.py
@@ -3,7 +3,7 @@ import subprocess
 import warnings
 from threading import Timer
 from collections import defaultdict
-from os import makedirs
+from os import makedirs, environ
 import os.path
 from hashlib import md5
 import time
@@ -722,19 +722,21 @@ class CTSText_TestUnit(TESTUnit):
         if self.countwords:
             tests.append("count_words")
 
-        if scheme.endswith("-ignore"):
-            scheme = scheme.replace("-ignore", "")
-        else:
+        if scheme in["tei", "epidoc", "auto_rng", "local_file"]:
             tests = [scheme] + tests
 
         self.scheme = scheme
         self.guidelines = guidelines
         self.rng = rng
-
+        if environ.get("HOOKTEST_DEBUG", False):
+            print("Starting %s " % self.path)
         i = 0
         for test in tests:
 
             # Show the logs and return the status
+
+            if environ.get("HOOKTEST_DEBUG", False):
+                print("\t Testing %s " % test)
             status = False not in [status for status in getattr(self, test)()]
             self.test_status[test] = status
             yield (CTSText_TestUnit.readable[test], status, self.logs)

--- a/HookTest/test.py
+++ b/HookTest/test.py
@@ -124,7 +124,7 @@ class Test(object):
     SCHEMES = {
         "tei": "tei.rng",
         "epidoc": "epidoc.rng",
-        "ignore": "epidoc.rng",
+        "ignore": None,
         "auto": "auto_rng"
     }
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,13 @@ The command is run with :code:`hooktest [-h] [-w WORKERS] [-s SCHEME] [-v] [-j J
 | --allowfailure                         | Returns a passing test result as long as at least one text passes    |
 +----------------------------------------+----------------------------------------------------------------------+
 
+Debugging
+#########
+
+Note that you can run some debugging function adding `HOOKTEST_DEBUG=True` before your command : `HOOKTEST_DEBUG=True hooktest --console --scheme tei --workers 1 --verbose 10  --countword --allowfailure ./ --scheme ignore`.
+It will display more informations in case tests struggle to go from one file to another. We recommend using only one worker in this context.
+
+
 Running HookTest on Travis CI
 #############################
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
 
 setup(
     name='HookTest',
-    version="1.2.2",
+    version="1.2.3",
     description='Hook Test Script for GitHub/CapiTainS repositories',
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/tests/test_repositories/test_wrong_tei/data/hafez/__cts__.xml
+++ b/tests/test_repositories/test_wrong_tei/data/hafez/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="farsiLit:hafez" urn="urn:cts:farsiLit:hafez">
+        <ti:groupname xml:lang="eng">Hafez</ti:groupname>
+        </ti:textgroup>
+    

--- a/tests/test_repositories/test_wrong_tei/data/hafez/divan/__cts__.xml
+++ b/tests/test_repositories/test_wrong_tei/data/hafez/divan/__cts__.xml
@@ -1,0 +1,23 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:farsiLit:hafez" urn="urn:cts:farsiLit:hafez.divan" xml:lang="fa">
+    <ti:title xml:lang="eng">Div&#257;n</ti:title>
+    <ti:edition urn="urn:cts:farsiLit:hafez.divan.perseus-far1" workUrn="urn:cts:farsiLit:hafez.divan">
+        <ti:label xml:lang="eng">Div&#257;n</ti:label>
+        <ti:description xml:lang="eng">Perseus:bib:oclc, 254557372. Diwan-i Hwaga Sams-ad-Din
+            Muhammad Hafiz Sirazi qaddas sarra-yi al-aziz ba tamam. edited by Muhammad
+            Qazwini and Qasim Gani as available on ganjoor.net. Tehran, Caphana-i Maglis.
+            1941. </ti:description>
+        </ti:edition>
+    <ti:translation  xml:lang="eng" urn="urn:cts:farsiLit:hafez.divan.perseus-eng1" workUrn="urn:cts:farsiLit:hafez.divan">
+        <ti:label xml:lang="eng">Div&#257;n (English)</ti:label>
+        <ti:description xml:lang="eng">Perseus:bib:oclc, 559481156. The D&#299;v&#257;n .Translated for
+            the first time out of the Persian into English prose, with critical and
+            explanatory remarks, with an introductory preface, with a note on &#7778;&#363;f&#299;ism, and
+            with a life of the author, by H. Wilberforce Clarke. Calcutta, India. 1891. </ti:description>
+        </ti:translation>
+    <ti:translation  xml:lang="ger" urn="urn:cts:farsiLit:hafez.divan.perseus-ger1" workUrn="urn:cts:farsiLit:hafez.divan">
+        <ti:label xml:lang="eng">Div&#257;n (German)</ti:label>
+        <ti:description xml:lang="eng">Perseus:bib:oclc, 6773200. Mohammed Schemsed-din Hafis,
+            Der Diwan, Aus dem Persischen zum erstenmal ganz &#252;bersetzt von Joseph von
+            Hammer-Purgstall. Stuttgart and T&#252;bingen, 1812. </ti:description>
+        </ti:translation>
+</ti:work>

--- a/tests/test_repositories/test_wrong_tei/data/hafez/divan/hafez.divan.perseus-ger1.xml
+++ b/tests/test_repositories/test_wrong_tei/data/hafez/divan/hafez.divan.perseus-ger1.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="some/stupid/path/to/epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <should_fail_whatever_this_should_be>
+            <titleStmt>
+                <title type="work">Divan</title>
+                <title type="sub">Machine readable text</title>
+                <author n="Hafez">Khwāja Shams-ud-Dīn Muhammad Hāfez-e Shīrāzī</author>
+                <editor role="editor"> Joseph Freiherr von Hammer Purgstall</editor>
+                <sponsor>Perseus Project, Tufts University</sponsor>
+                <principal>Gregory Crane</principal>
+                <respStmt>
+                    <resp>Prepared under the supervision of</resp>
+                    <name>Maryam Foradi</name>
+                    <name>Saeed Majidi</name>
+                </respStmt>
+                <funder n="org:HUM">Humboldt Foundation</funder>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>Leipzig University</publisher>
+                <pubPlace>Leipzig, Germany</pubPlace>
+                <authority>Open Philology Project Project</authority>
+            </publicationStmt>
+            <sourceDesc>
+                <bibl>
+                    <author>Khwāja Shams-ud-Dīn Muhammad Hāfez-e Shīrāzī</author>
+               
+                    <title>Divan</title>
+                    <pubPlace>Stuttgart and Tübingen</pubPlace>
+                    <publisher/>
+                    <date>1812</date>
+                </bibl>
+            </sourceDesc>
+        </should_fail_whatever_this_should_be>
+        <encodingDesc><refsDecl n="CTS">
+            <cRefPattern matchPattern="(\\w+).(\\w+).(\\w+).(\\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\']/tei:div[@n=\'$2\']/tei:l[@n=\'$3\']/tei:seg[@n=\'$4\'])">
+                <p>This pointer pattern extracts letter and poem and line and seg</p>
+            </cRefPattern>
+            <cRefPattern matchPattern="(\\w+).(\\w+).(\\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\']/tei:div[@n=\'$2\']/tei:l[@n=\'$3\'])">
+                <p>This pointer pattern extracts letter and poem and line</p>
+            </cRefPattern>
+            <cRefPattern matchPattern="(\\w+).(\\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\']/tei:div[@n=\'$2\'])">
+                <p>This pointer pattern extracts letter and poem</p>
+            </cRefPattern>
+            <cRefPattern matchPattern="(\\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\'])">
+                <p>This pointer pattern extracts letter</p>
+            </cRefPattern>
+        </refsDecl>
+            <refsDecl>
+                <refState unit="letter" delim="."/>
+                <refState unit="poem" delim="."/>
+                <refState unit="line" delim="."/>
+                <refState unit="misra"/>
+            </refsDecl>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fa">Farsi</language>
+                <language ident="de">German</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2014-11-01" who="Saeed Majidi">Automatically generated initial markup</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:lang="de">
+        <body>
+            <div type="translation" n="urn:cts:farsiLit:hafez.divan.perseus-ger1" xml:lang="ger">
+                <div type="textpart" subtype="letter" n="1" xml:id="Alif">
+                    <div type="textpart" subtype="poem" n="1">
+                        <l n="1">
+                            <seg n="1">Reich mir o Schenke das Glas, ### </seg>
+                            <seg n="2">Bringe den Gästen es zu, ### </seg>
+                            <seg n="3">Leicht' ist die Lieb' im Anfang ### </seg>
+                            <seg n="4">Es folgen aber Schwierigkeiten. *** </seg>
+                        </l>
+                        <l n="2">
+                            <seg n="1">Wegen des Moschusgeruchs, ### </seg>
+                            <seg n="2">Welchen der Ostwind geraubt ### </seg>
+                            <seg n="3">Deinen gekrau'sten Locken, ### </seg>
+                            <seg n="4">Wie vieles Blut entfloß dem Herzen! *** </seg>
+                        </l>
+                        <l n="3">
+                            <seg n="1">Folge dem Worte des Wirths ### </seg>
+                            <seg n="2">Färbe den Teppich mit Wein. ### </seg>
+                            <seg n="3">Reisende sind der Wege, ### </seg>
+                            <seg n="4">Sie sind des Laufs der Posten kundig. *** </seg>
+                        </l>
+                        <l n="4">
+                            <seg n="1">Kann ich genießen der Lust ### </seg>
+                            <seg n="2">In des Geliebten Gezelt, ### </seg>
+                            <seg n="3">Wenn mich zum Aufbruch immer ### </seg>
+                            <seg n="4">Der Karawane Glocke rufet! *** </seg>
+                        </l>
+                        <l n="5">
+                            <seg n="1">Finstere Schatten der Nacht! ### </seg>
+                            <seg n="2">Wogen und Wirbelgefahr, ### </seg>
+                            <seg n="3">Können Euch wohl begreifen, ### </seg>
+                            <seg n="4">Die leicht geschürzt am Ufer wohnen? *** </seg>
+                        </l>
+                        <l n="6">
+                            <seg n="1">Durch die befriedigte Lust ### </seg>
+                            <seg n="2">Ward ich zum Mährchen der Stadt, ### </seg>
+                            <seg n="3">Kann ein Geheimniß bleiben ### </seg>
+                            <seg n="4">Der Stoff der allgemeinen Sage? *** </seg>
+                        </l>
+                        <l n="7">
+                            <seg n="1">Wünschest du Ruhe Hafis, ### </seg>
+                            <seg n="2">Folge dem köstlichen Rath: ### </seg>
+                            <seg n="3">Willst du das Liebchen finden, ### </seg>
+                            <seg n="4">Verlaß die Welt und laß sie gehen. *** </seg>
+                        </l>
+                    </div>
+                    
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -338,6 +338,34 @@ class TestProcess(TestCase):
         self.assertEqual(status, "failed", "Test should fail")
         shutil.rmtree('./.rngs/')
 
+    def test_run_local_console_verbose_no_scheme(self):
+        """ Test a run on the local tests passages with console print with no RNG run """
+        status, logs = self.hooktest([
+            "./tests/test_repositories/test_wrong_tei", "--console", "--verbose", "--scheme", "ignore", "--guidelines", "2.epidoc"])
+        self.assertLogResult(
+            logs, "Metadata Files", "2",
+            "2 metadata files should be described in logs"
+        )
+        self.assertLogResult(
+            logs, "Passing Metadata", "2",
+            "2 metadata files should be passing in logs"
+        )
+        self.assertLogResult(
+            logs, "Total Texts", "1",
+            "3 texts should be described in logs"
+        )
+        self.assertLogResult(
+            logs, "Passing Texts", "1",
+            "2 texts should be passing in logs"
+        )
+        node_count, unit = self.parse_subset(logs, "hafez.divan.perseus-ger1.xml")
+        self.assertEqual(
+            node_count, "1;1;7;28",
+            "Correct node counts should be displayed for file using remote RNG"
+        )
+
+        self.assertEqual(status, "success", "Test should success")
+
     def test_run_local_console_verbose_path_to_rng_success(self):
         """ Test a run on the local tests passages with --scheme as local RNG path """
         status, logs = self.hooktest([


### PR DESCRIPTION
- Added ability to do `HOOKTEST_DEBUG=True` for printing more information during run.